### PR TITLE
Agrega test para la funcion pow que pasa parametro negativo

### DIFF
--- a/test/core.test.js
+++ b/test/core.test.js
@@ -18,4 +18,8 @@ describe('Pow', () => {
     test('Deberia 12 ^ 2 = 144', () => {
         expect(core.pow(12)).toBe(144); 
     })
+
+    test('Deberia -2 ^ 2 = 4', () => {
+        expect(core.pow(-2)).toBe(4);
+    })
 })


### PR DESCRIPTION
Añado test para la comprobación de que el resultado es un numero positivo cuando se le pasa un numero negativo como parametro a la función "pow" mediante la siguiente cuenta, solicitando que el mismo sea agregado a la rama "dev":
-2^2 = 4 