### PR TITLE
Arreglo test para la funcion pow que pasa parametro negativo

### DIFF
--- a/test/core.test.js
+++ b/test/core.test.js
@@ -19,7 +19,7 @@ describe('Pow', () => {
         expect(core.pow(12)).toBe(144); 
     })
 
-    test('Deberia -2 ^ 2 = 4', () => {
-        expect(core.pow(-2)).toBe(4);
+    test('Deberia -2 ^ 2 = numero positivo', () => {
+        expect(core.pow(-2)).toBeGreaterThan(0);
     })
 })


### PR DESCRIPTION
Arreglo test para la comprobación de que el resultado es un numero positivo cuando se le pasa un numero negativo como parametro a la función "pow" mediante la siguiente cuenta, solicitando que el mismo sea agregado a la rama "dev":
-2^2 = numero positivo