### PR TITLE
arreglo test para la funcion sub que da resultado negativo

### DIFF
--- a/test/core.test.js
+++ b/test/core.test.js
@@ -10,7 +10,7 @@ describe('Subtract', () => {
     })
 
     test('Deberia 6 - 8 = -2', () => {
-        expect(core.sub(6, 8)).toBe(-2); 
+        expect(core.sub(6, 8)).toBeLessThan(0); 
     })
 })
 


### PR DESCRIPTION
Arreglo el test para la comprobación de que el resultado es un número negativo cuando el segundo parámetro es mayor que el primero para la función "sub" mediante la siguiente cuenta, solicitando que el mismo sea agregado a la rama "dev": 6 - 8
= -2