### PR TITLE
Arreglo el mensaje de error para el método GET /mul/:a/:b

### DIFF
--- a/src/controllers.js
+++ b/src/controllers.js
@@ -49,7 +49,7 @@ router.get("/mul/:a/:b", async function (req, res) {
     const b = Number(params.b);
 
     if (isNaN(a) || isNaN(b)) {
-        res.status(400).send('Uno de los parámetros no es un número');
+        res.status(400).send({"error":'Uno de los parámetros no es un número'});
     } else {
         const result = core.mul(a, b);
         return res.send({ result });


### PR DESCRIPTION
Arreglo el mensaje de error para el método GET /mul/:a/:b, cuando los parámetros no son números para que se muestren en formato json como el resto de los resultados.