### PR TITLE
Arreglo mensaje de error para el metodo GET /pow/:a

### DIFF
--- a/src/controllers.js
+++ b/src/controllers.js
@@ -22,7 +22,7 @@ router.get("/pow/:a", async function (req, res) {
     const a = Number(params.a);
 
     if (isNaN(a)) {
-        res.status(400).send('Uno de los parámetros no es un número');
+        res.status(400).send({"error":'Uno de los parámetros no es un número'});
     } else {
         const result = core.pow(a);
         return res.send({ result });


### PR DESCRIPTION
Cambio el mensaje de error que muestra la aplicación cuando se envía un parámetro que no es un número en el método Pow, anteriormente se mostraba un mensaje de String.