### PR TITLE
Arreglo mensaje de error para el metodo GET /add/:a/:b

### DIFF
--- a/src/controllers.js
+++ b/src/controllers.js
@@ -22,7 +22,7 @@ router.get("/add/:a/:b", async function (req, res) {
     const b = Number(params.b);
     
     if (isNaN(a) || isNaN(b)) {
-        res.status(400).send('Uno de los parámetros no es un número');
+        res.status(400).send({"error":'Uno de los parámetros no es un número'});
     } else {
         const result = core.add(a, b);
         return res.send({ result });


### PR DESCRIPTION
Arreglo el mensaje de error para el método GET /add/:a/:b, cuando los parámetros no son números para que se muestren en formato JSON como el resto de los resultados.