### PR TITLE
Arreglo error al guardar segundo argumento en History

### DIFF
--- a/src/models.js
+++ b/src/models.js
@@ -42,6 +42,7 @@ export async function createHistoryEntry({ firstArg, secondArg, operationName, r
 
     return History.create({
         firstArg,
+        secondArg,
         result,
         OperationId: operation.id
     })


### PR DESCRIPTION
Agrego el atributo secondArgs que se pasaba como parámetro pero que no se incorporaba a la lista de atributos del History