### PR TITLE
Agrego parámetro result para la función createHistoryEntry

### DIFF
--- a/src/controllers.js
+++ b/src/controllers.js
@@ -15,7 +15,7 @@ router.get("/sub/:a/:b", async function (req, res) {
     } else {
         const result = core.sub(a, b);
 
-        await createHistoryEntry({ firstArg: a, secondArg: b, operationName: "SUB" })
+        await createHistoryEntry({ firstArg: a, secondArg: b, result, operationName: "SUB" })
         return res.send({ result });
     }
 });


### PR DESCRIPTION
Agrego el parámetro result para la función createHistoryEntry para que en la base de datos se persista el resultado y no null.