### PR TITLE
Agrego test para el endpoint del id

### DIFF
--- a/test/api.test.js
+++ b/test/api.test.js
@@ -59,3 +59,15 @@ describe("API power", () => {
 })
 
 
+describe("API id", () => {
+    test("Deberia responder con un 200 ok", async () => {
+        const app = await api.build()
+
+        return request(app).get('/api/v1/id/45')
+            .expect(404)
+            .expect('Content-Type', "application/json; charset=utf-8")
+            .then((err) => {
+                expect(err.body.error).toEqual("No se encontró ninguna entrada de historial con el ID proporcionado");
+            })      
+    })
+})

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -60,7 +60,7 @@ describe("API power", () => {
 
 
 describe("API id", () => {
-    test("Deberia responder con un 200 ok", async () => {
+    test("Deberia responder con un 404 ok", async () => {
         const app = await api.build()
 
         return request(app).get('/api/v1/id/45')


### PR DESCRIPTION
Agrego test para verificar que el endpoint de id devuelve un status 404 cuando se pasa un id que no esta en la base de datos.