### PR TITLE
Modifico test para el endpoint de multiplicacion

### DIFF
--- a/test/api.test.js
+++ b/test/api.test.js
@@ -27,7 +27,7 @@ describe("API multiply", () => {
             .expect(200)
             .expect('Content-Type', "application/json; charset=utf-8")
             .then((res) => {
-                expect(res.body.result).toBeCloseTo(16.74);
+                expect(res.body.result).not.toEqual(parseInt(3.1*5.4));
             })
     })
 })


### PR DESCRIPTION
Modifico el test para el endpoint de multiplicación para que devuelva un status 200 cuando ambos parámetros son decimales y así verificar que el resultado sea con decimales, anteriormente solo se comparaba que los números sean iguales y no que el resultado sea con decimales.