### PR TITLE
Modifico el test para guardar el atributo error

### DIFF
--- a/test/models.test.js
+++ b/test/models.test.js
@@ -54,7 +54,7 @@ describe("History", () => {
             secondArg: 4,
             result: -6,
             operationName: "SUB",
-            error: null
+            error: 'Uno de los parámetros no es un número'
         })
 
         const histories = await History.findAll({
@@ -66,6 +66,6 @@ describe("History", () => {
         expect(histories[0].secondArg).toEqual(4)
         expect(histories[0].result).toEqual(-6)
         expect(histories[0].Operation.name).toEqual("SUB")
-        expect(histories[0].error).toEqual(null)
+        expect(histories[0].error).toEqual('Uno de los parámetros no es un número')
     })
 })


### PR DESCRIPTION
Modifico el test para guardar el atributo error en el history ya que antes se testeaba que se guarde null que es el valor por default del atributo error, ahora se le da otro valor y se lo testea.