### PR TITLE
Arreglo el bug de resta para numeros negativos y su respectivo test

### DIFF
--- a/src/public/index.js
+++ b/src/public/index.js
@@ -12,12 +12,18 @@ $buttons.addEventListener('click', async (e) => {
     const nextAction = e.target.name
 
     if (nextAction === "=") {
+        let negative = false;
+        if (currentDisplay.startsWith("-")&& operation === "-")
+        {
+            currentDisplay = currentDisplay.slice(1)
+            negative = true;
+        }
         const [firstArg, secondArg] = currentDisplay.split(operation)
 
         let result;
-
+        
         if (operation === "-") {
-            result = await calculateSub(firstArg, secondArg)
+            result = await calculateSub(negative ? firstArg*(-1): firstArg, secondArg)
         }
 
         if (operation === "binary") {

--- a/test/ui.test.js
+++ b/test/ui.test.js
@@ -257,4 +257,39 @@ test.describe('test', () => {
       expect(historyEntry.firstArg).toEqual(9)
       expect(historyEntry.result).toEqual(1001)
     });
+
+    test('Deberia realizar una resta con numeros negativos', async ({ page }) => {
+      await page.goto('./');
+    
+      await page.getByRole('button', { name: '-' }).click()
+      await page.getByRole('button', { name: '6' }).click()
+      await page.getByRole('button', { name: '3' }).click()
+      await page.getByRole('button', { name: '-' }).click()
+      await page.getByRole('button', { name: '3' }).click()
+    
+      const [response] = await Promise.all([
+        page.waitForResponse((r) => r.url().includes('/api/v1/sub/')),
+        page.getByRole('button', { name: '=' }).click()
+      ]);
+    
+      const { result } = await response.json();
+      expect(result).toBe(-66);
+    
+      await expect(page.getByTestId('display')).toHaveValue(/-66/)
+    
+      const operation = await Operation.findOne({
+        where: {
+          name: "SUB"
+        }
+      });
+    
+      const historyEntry = await History.findOne({
+        where: { OperationId: operation.id }
+      })
+    
+      expect(historyEntry.firstArg).toEqual(-63)
+      expect(historyEntry.secondArg).toEqual(3)
+      expect(historyEntry.result).toEqual(-66)
+    });
 })
+


### PR DESCRIPTION
La calculadora no permitía ingresar números negativos, tomaba el “-” siempre como una operación. Ahora permite ingresar números negativos para operar sobre ellos. 
Realizo el test e2e correspondiente.